### PR TITLE
feat: Release notes information button on Updates page

### DIFF
--- a/i18n/en/cosmic_store.ftl
+++ b/i18n/en/cosmic_store.ftl
@@ -59,7 +59,6 @@ settings = Settings
 ## Release notes
 latest-version = Latest version
 no-description = No description available.
-release-notes = Release notes
 
 ### Appearance
 appearance = Appearance

--- a/i18n/en/cosmic_store.ftl
+++ b/i18n/en/cosmic_store.ftl
@@ -56,6 +56,11 @@ monthly-downloads = Flathub Monthly Downloads
 ## Settings
 settings = Settings
 
+## Release notes
+latest-version = Latest version
+no-description = No description available.
+release-notes = Release notes
+
 ### Appearance
 appearance = Appearance
 theme = Theme

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ pub enum ContextPage {
 impl ContextPage {
     fn title(&self) -> String {
         match self {
-            Self::ReleaseNotes(_) => fl!("release-notes"),
+            Self::ReleaseNotes(_) => String::default(),
             Self::Settings => fl!("settings"),
         }
     }


### PR DESCRIPTION
Closes: #56 

Unfortunately, I upgrade my test VM fairly often so I couldn't take great screenshots.

![info_button01](https://github.com/pop-os/cosmic-store/assets/48846352/86ababe1-7f63-4ca3-a9dd-2750f644b3c5)
![info_button04](https://github.com/pop-os/cosmic-store/assets/48846352/50aac40f-c702-4248-bc33-4652fef18c44)

## Updates
* Switched the version header to `title4`
* Removed the title from the release notes page