### PR TITLE
Update libcosmic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "atomicwrites 0.4.2",
  "cosmic-config-derive",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "futures",
  "iced_core",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3296,7 +3296,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#2dd55f2f20cc0a5bd09f834779dd6cf1dcb23bcf"
+source = "git+https://github.com/pop-os/libcosmic.git#a5996b4e90f6aad943b7c61b961fae5edacd7697"
 dependencies = [
  "apply",
  "ashpd",


### PR DESCRIPTION
Not updated to latest since the `spawn_desktop_exec` function in libcosmic was changed to async, and I'm not sure what needs to be changed for it to work in the call in cosmic-store.
This is just so that all apps have double-click to maximize for the alpha.