### PR TITLE
packagekit(load_caches): Add cache-age hint and set it to 5 mins

### DIFF
--- a/src/backend/packagekit.rs
+++ b/src/backend/packagekit.rs
@@ -299,10 +299,8 @@ impl Backend for Packagekit {
     fn load_caches(&mut self, refresh: bool) -> Result<(), Box<dyn Error>> {
         if refresh {
             let tx = self.transaction()?;
-            tx.set_hints(&["interactive=true"])?;
-            //TODO: force refresh?
-            let force = false;
-            tx.refresh_cache(force)?;
+            tx.set_hints(&["interactive=true", "cache-age=300"])?;
+            tx.refresh_cache(false)?;
         }
 
         for appstream_cache in self.appstream_caches.iter_mut() {


### PR DESCRIPTION
This fixes the updates page not showing any new system updates on Fedora, see https://invent.kde.org/plasma/discover/-/merge_requests/640.

###### (To my knowledge, cache-age is only implemented in the DNF backend, so it shouldn't affect other backends)