### PR TITLE
Fixed Japanese translation for Cosmic Store (i18n/ja/cosmic_store.ftl)

### DIFF
--- a/i18n/ja/cosmic_store.ftl
+++ b/i18n/ja/cosmic_store.ftl
@@ -1,72 +1,72 @@
 app-name = COSMICアップストア
 back = 戻る
 cancel = キャンセル
-check-for-updates = アップデートを確認
-checking-for-updates = 確認中...
+check-for-updates = アップデートの確認
+checking-for-updates = アップデートを確認中です...
 install = インストール
-no-installed-applications = インストールされているアプリケーションはありません。
-no-updates = アプリケーションはすべて最新版です。
-no-results = 「{$search}」の検索結果はありません。
-notification-progress = インストレーションとアップデートは行われています。
+no-installed-applications = インストール済みのアプリはありません。
+no-updates = アプリはすべて最新です。
+no-results = 「{$search}」を含む結果はありません。
+notification-progress = インストールとアップデートを実行中です...
 open = 開く
-see-all = すべてを表示
+see-all = すべて表示
 uninstall = アンインストール
 update = アップデート
-update-all = すべてをアップデート
+update-all = すべてアップデート
 
 # Progress footer
-details = 詳細
-dismiss = メッセージを閉じる
-operations-running = {$running}つの操作が実行中... ({$percent}%)
-operations-running-finished = {$running}つの操作が実行中({$percent}%), {$finished}つのが完了です...
+details = 詳細を見る
+dismiss = 閉じる
+operations-running = {$running}件の操作を実行です ({$percent}%)
+operations-running-finished = {$running}件の操作を実行中({$percent}%)、 {$finished}件が完了しました
 
 # Uninstall Dialog
-uninstall-app = {$name}のアンインストール
-uninstall-app-warning = 本当に{$name}をアンインストールしてよろしいですか？
+uninstall-app = {$name}をアンインストール
+uninstall-app-warning = 本当に{$name}をアンインストールしてもよろしいですか？
 
 # Nav Pages
-explore = 一覧
-create = 作成
-work = 仕事
-develop = 開発
-learn = 学習
-game = 遊び
-relax = リラックス
-socialize = ソーシャルメディア
-utilities = ユティリティ
-installed-apps = インストール込みアップ
-updates = アップデートリスト
+explore = 探す
+create = クリエイティブ
+work = ワーク
+develop = ソフトウェア開発
+learn = ラーニング
+game = ゲーム
+relax = エンタメ
+socialize = ソーシャル
+utilities = ツール
+installed-apps = インストール済みアプリ
+updates = アップデート情報
 
 # Explore Pages
-editors-choice = エディターズチョイス
-popular-apps = 人気なアプリ
-made-for-cosmic = COSMICのために作られた
-new-apps = 新しいアプリ
-recently-updated = 最近にアップデートされた
+editors-choice = おすすめ
+popular-apps = 人気アプリ
+made-for-cosmic = COSMIC限定アプリ
+new-apps = 新着アプリ
+recently-updated = 最近アップデートされたアプリ
 development-tools = 開発ツール
-scientific-tools = 科学的なツール
-productivity-apps = プロダクティビティー
-graphics-and-photography-tools = グラフィックスと写真
-social-networking-apps = SNSのアプリ
+scientific-tools = 科学ツール
+productivity-apps = 仕事効率化アプリ
+graphics-and-photography-tools = グラフィックス・写真用ツール
+social-networking-apps = SNSアプリ
 games = ゲーム
-music-and-video-apps = 音楽とビデオのアプリ
-apps-for-learning = 学びのアプリ
+music-and-video-apps = 音楽・動画アプリ
+apps-for-learning = 学習アプリ
 
 # Details Page
-source-installed = {$source} (インストール済み)
+source-installed = {$source}（インストール済み）
 developer = 開発者
 app-developers = {$app}の開発者
-monthly-downloads = 月例のFlathubからのダウンロード
+monthly-downloads = 月間ダウンロード数（Flathub）
 licenses = ライセンス
 proprietary = プロプライエタリ
 
 ## App URLs
-bug-tracker = バッグトラッカー
-contact = 連絡
+bug-tracker = バグ追跡
+contact = お問い合わせ
 donation = 寄付
-faq = FAQ
+faq = よくある質問
 help = ヘルプ
-homepage = ホームページ
+homepage = 公式サイト
 translate = 翻訳
 
 # Context Pages
@@ -74,7 +74,7 @@ translate = 翻訳
 ## Operations
 cancelled = 中止
 operations = 操作
-no-operations = 歴史には操作がありません。
+no-operations = 履歴に操作が見つかりませんでした。
 pending = 実行中
 failed = 失敗
 complete = 完了
@@ -89,6 +89,6 @@ no-description = 説明はありません。
 ### Appearance
 appearance = 外観
 theme = テーマ
-match-desktop = システム設定に従う
+match-desktop = システム設定に合わせる
 dark = ダーク
 light = ライト


### PR DESCRIPTION
I have revised the text to ensure it sounds natural in Japanese overall. Specifically, I made the following improvements:

- Adjusted the word order and expressions to make it easier to read.

- Replaced words that would sound unnatural in any translation with familiar and suitable Japanese equivalents.

If you have any questions about the revisions or need additional adjustments, please feel free to reach out.