### PR TITLE
fix: Call `malloc_trim` only on glibc systems

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -108,7 +108,7 @@ pub fn backends(locale: &str, refresh: bool) -> Backends {
     });
 
     //TODO: Workaround for xml-rs memory leak when loading appstream data
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     {
         let start = Instant::now();
         unsafe {


### PR DESCRIPTION
`malloc_trim` is provided only by glibc and doesn't exist in other libc implementations, including musl.

Fixes #62 