### PR TITLE
Update Cargo.toml to strip the release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ wgpu = ["libcosmic/wgpu"]
 inherits = "release"
 debug = true
 
+[profile.release]
+strip = true
+
 [workspace]
 members = ["flathub-stats"]
 


### PR DESCRIPTION
Strip the binary for the release build.