### PR TITLE
feat: place on desktop functionality for installed applets

### DIFF
--- a/i18n/en/cosmic_store.ftl
+++ b/i18n/en/cosmic_store.ftl
@@ -14,6 +14,11 @@ uninstall = Uninstall
 update = Update
 update-all = Update all
 place-on-desktop = Place on desktop
+place-applet = Place applet
+place-applet-desc = Choose where to add the applet before refining its position.
+panel = Panel
+dock = Dock
+place-and-refine = Place and refine
 
 # Progress footer
 details = Details

--- a/i18n/en/cosmic_store.ftl
+++ b/i18n/en/cosmic_store.ftl
@@ -13,6 +13,7 @@ see-all = See all
 uninstall = Uninstall
 update = Update
 update-all = Update all
+place-on-desktop = Place on desktop
 
 # Progress footer
 details = Details

--- a/src/main.rs
+++ b/src/main.rs
@@ -1725,6 +1725,7 @@ impl App {
                 }
                 let is_installed =
                     self.is_installed(selected.backend_name, &selected.id, &selected.info);
+                let applet_provide = AppProvide::Id("com.system76.CosmicApplet".to_string());
                 let mut update_opt = None;
                 if let Some(updates) = &self.updates {
                     for (backend_name, package) in updates {
@@ -1792,11 +1793,19 @@ impl App {
                 } else if is_installed {
                     //TODO: what if there are multiple desktop IDs?
                     if let Some(desktop_id) = selected.info.desktop_ids.first() {
-                        buttons.push(
-                            widget::button::suggested(fl!("open"))
-                                .on_press(Message::OpenDesktopId(desktop_id.clone()))
-                                .into(),
-                        );
+                        if selected.info.provides.contains(&applet_provide) {
+                            buttons.push(
+                                widget::button::suggested(fl!("place-on-desktop"))
+                                    .on_press(Message::OpenDesktopId(desktop_id.clone()))
+                                    .into(),
+                            );
+                        } else {
+                            buttons.push(
+                                widget::button::suggested(fl!("open"))
+                                    .on_press(Message::OpenDesktopId(desktop_id.clone()))
+                                    .into(),
+                            );
+                        }
                     }
                     if let Some(update) = update_opt {
                         buttons.push(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use cosmic::{
         Alignment, Length, Limits, Size, Subscription,
     },
     theme,
-    widget::{self, segmented_button::Selectable},
+    widget::{self},
     Application, ApplicationExt, Element,
 };
 use localize::LANGUAGE_SORTER;
@@ -715,8 +715,6 @@ pub struct App {
     search_results: Option<(String, Vec<SearchResult>)>,
     selected_opt: Option<Selected>,
     applet_placement_buttons: cosmic::widget::segmented_button::SingleSelectModel,
-    applet_place_panel: cosmic::widget::segmented_button::Entity,
-    applet_place_dock: cosmic::widget::segmented_button::Entity,
 }
 
 impl App {
@@ -2512,8 +2510,6 @@ impl Application for App {
 
         let mut applet_placement_buttons =
             cosmic::widget::segmented_button::SingleSelectModel::builder().build();
-        let applet_place_panel = applet_placement_buttons.insert().text(fl!("panel")).id();
-        let applet_place_dock = applet_placement_buttons.insert().text(fl!("dock")).id();
         applet_placement_buttons.activate_position(0);
 
         let mut app = App {
@@ -2552,8 +2548,6 @@ impl Application for App {
             search_results: None,
             selected_opt: None,
             applet_placement_buttons,
-            applet_place_panel,
-            applet_place_dock,
         };
 
         if let Some(subcommand) = flags.subcommand_opt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2510,6 +2510,8 @@ impl Application for App {
 
         let mut applet_placement_buttons =
             cosmic::widget::segmented_button::SingleSelectModel::builder().build();
+        let _ = applet_placement_buttons.insert().text(fl!("panel")).id();
+        let _ = applet_placement_buttons.insert().text(fl!("dock")).id();
         applet_placement_buttons.activate_position(0);
 
         let mut app = App {


### PR DESCRIPTION
Implements https://github.com/pop-os/cosmic-store/issues/293

Submitting as draft as currently each option only opens the general page for the Panel or Dock, and not their specific applet pages. I believe cosmic-settings will need to be modified to accept launch commands for these pages, along with corresponding desktop files.