### PR TITLE
feat: add support for quitting program with hotkeys

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -57,6 +57,7 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     }
 
     bind!([Ctrl], Key::Character("f".into()), SearchActivate);
+    bind!([Ctrl], Key::Character("q".into()), WindowClose);
 
     key_binds
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,12 +165,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Action {
     SearchActivate,
+    WindowClose,
 }
 
 impl Action {
     pub fn message(&self) -> Message {
         match self {
             Self::SearchActivate => Message::SearchActivate,
+            Self::WindowClose      => Message::WindowClose,
         }
     }
 }


### PR DESCRIPTION
This allows the program to be closed by pushing `Ctrl-Q`

Tested against Pop!_OS 24.04LTS by performing the following:

1. Open the System Monitor and COSMIC Terminal
2. From the terminal run `cargo run`
3. Press `Ctrl` and `Q` in unison
4. Watch the window close
5. Observe stdout pipe close and logging end in COSMIC Terminal
6. Observe the process die in System Monitor

There happened to be an update available to my Flatpak install of GIMP, so just to be safe I kicked off the update and quickly pressed the hotkey sequence. System Monitor showed that the process didn't die until the update was completed.

Edit to add: This closes #469 