### PR TITLE
docs: Add QA testing checklist

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,12 @@
+# Testing
+
+This document provides a regression testing checklist for the COSMIC Store. The checklist provides a starting point for Quality Assurance reviews.
+
+## Checklist
+
+- [ ] Able to install & remove a Flatpak app.
+- [ ] Able to install & remove a Deb app.
+- [ ] Able to install Deb updates.
+- [ ] Searching still works.
+- [ ] Browsing categories still works.
+- [ ] Able to remove & re-add Flatpak sources.


### PR DESCRIPTION
Codifies a few common checks for COSMIC Store PRs.

The reason I included updating Deb apps and not updating Flatpak apps is because Deb apps are very easy to force updates for (you can simply install a local version, or a version from a different source). Flatpak tracks sources and won't offer to update an app originally installed from one source to a version from a different source, so these common methods don't work. Flatpak does have some limited downgrading capability, but it relies on cache that Flathub often clears and our COSMIC repo may not keep at all. If we come up with a good way to force Flatpak updates, then we can add that test to the checklist later.