### PR TITLE
Remove `packagekit` from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ default = [
     "flatpak",
     "logind",
     "notify",
-    "packagekit",
     "single-instance",
     "wgpu",
     "wayland",

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_clean:
 	fi
 
 override_dh_auto_build:
-	just build-vendored
+	just build-vendored --features packagekit
 
 override_dh_auto_install:
 	just rootdir=$(DESTDIR) install


### PR DESCRIPTION
This allows distros that don't work well with packagekit (e.g. Arch) to more easily and reliably exclude it. Other distros can just add it to their build scripts.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

