### PR TITLE
fix: force cache update when using update check button

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -125,7 +125,7 @@ impl App {
                 //TODO: this only checks updates if they have already been checked
                 if self.updates.take().is_some() {
                     if self.pending_operations.is_empty() {
-                        return self.update_backends(false);
+                        return self.update_backends(true);
                     } else {
                         log::warn!("cannot check for updates, operations are in progress");
                     }


### PR DESCRIPTION
Force a cache update when clicking the "Check for updates" button.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

