### PR TITLE
Allowing Cosmic-Store to be proposed as default in cosmic files to open .rpm file

### DIFF
--- a/res/com.system76.CosmicStore.desktop
+++ b/res/com.system76.CosmicStore.desktop
@@ -8,4 +8,4 @@ StartupNotify=true
 Icon=com.system76.CosmicStore
 Categories=COSMIC;System;PackageManager;
 Keywords=App;Software;Store;Shop;
-MimeType=application/x-debian-package;application/vnd.debian.binary-package;application/vnd.flatpak.ref;x-scheme-handler/appstream;x-scheme-handler/mime;
+MimeType=application/x-debian-package;application/vnd.debian.binary-package;application/vnd.flatpak.ref;x-scheme-handler/appstream;x-scheme-handler/mime;application/x-rpm;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

I've seen an issue in the cosmic-files repo concerning the fact that the files manager doesn't propose cosmic-store to open rpm file by default : https://github.com/pop-os/cosmic-files/issues/1764

I've changed the com.System76.CosmicStore.desktop to add the support and now after rebuilding and reinstalling it works. 
