### PR TITLE
Pin aws-lc-rs for RPM hardened builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -555,15 +555,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pin `aws-lc-rs` to 1.17.0 (`aws-lc-sys` 0.41.0) to work around the x86_64 RPM hardened-build regression in `aws-lc-sys` 0.42.0.

`aws-lc-sys` 0.42.0's `memcmp_invalid_stripped_check` ignores `CFLAGS` while retaining `LDFLAGS`. Fedora supplies `-fPIE` through `CFLAGS` and `-pie` through `LDFLAGS`, so the probe compiles a non-PIE object and then fails to link it as PIE.

- Upstream issue: https://github.com/aws/aws-lc-rs/issues/1168
- Failing COSMIC Store 1.2.0 COPR build: https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch-tagged/build/10699780/

This keeps the existing rustls AWS-LC provider and post-quantum behavior, unlike switching crypto providers.

## Validation

Built successfully on Fedora 44 x86_64 with Fedora's RPM hardening flags and the package features used by the Fedora spec:

```sh
CFLAGS="$(rpm --eval '%{build_cflags}')" \
CXXFLAGS="$(rpm --eval '%{build_cxxflags}')" \
LDFLAGS="$(rpm --eval '%{build_ldflags}')" \
cargo build --release --locked --features packagekit,rpm-ostree
```
