### PR TITLE
Gallery mode and screenshot cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,12 +286,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -293,6 +328,15 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ash"
@@ -544,6 +588,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitcode"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -719,6 +821,12 @@ checksum = "3b5ab9db53bcda568284df0fd39f6eac24ad6f7ba7ff1168b9e76eba6576b976"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -1215,6 +1323,7 @@ dependencies = [
  "i18n-embed-fl",
  "icu_collator",
  "icu_locale",
+ "image",
  "libc",
  "libcosmic",
  "libflatpak",
@@ -1742,6 +1851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1933,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1960,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2227,6 +2379,16 @@ name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -3130,9 +3292,18 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif 0.14.2",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.15",
 ]
@@ -3161,6 +3332,12 @@ name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -3203,6 +3380,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3254,6 +3442,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -3475,6 +3672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,6 +3763,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
@@ -3674,6 +3887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3758,6 +3980,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3927,6 +4159,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,6 +4181,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -3977,10 +4230,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4389,6 +4693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4693,12 +5003,57 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "quick-error"
@@ -4891,6 +5246,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4936,6 +5350,12 @@ dependencies = [
  "bytemuck",
  "font-types",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_event"
@@ -5075,7 +5495,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
- "gif",
+ "gif 0.13.3",
  "image-webp",
  "log",
  "pico-args",
@@ -5614,6 +6034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6050,6 +6479,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -6573,6 +7016,17 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -7922,6 +8376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8187,6 +8647,15 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 freedesktop_entry_parser = "2"
 futures = "0.3"
+image = "0.25"
 log = "0.4"
 open = "5"
 paste = "1"

--- a/src/app_info.rs
+++ b/src/app_info.rs
@@ -169,6 +169,15 @@ pub struct AppInfo {
 }
 
 impl AppInfo {
+    /// Latest release version, or "" if unknown. Used to key cached screenshots
+    /// so a new app version refetches them instead of showing stale images.
+    pub fn version(&self) -> &str {
+        self.releases
+            .first()
+            .map(|release| release.version.as_str())
+            .unwrap_or_default()
+    }
+
     pub fn new(
         source_id: &str,
         source_name: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,8 @@ mod stats;
 
 mod preview_cache;
 
+mod screenshot_image;
+
 use explore::ExplorePage;
 mod explore;
 
@@ -345,6 +347,7 @@ pub enum Message {
     SelectSearchResult(usize),
     SelectedAddonsViewMore(bool),
     SelectedScreenshot(usize, String, Vec<u8>),
+    SelectedScreenshotDecoded(usize, String, u32, u32, Vec<u8>),
     SelectedScreenshotShown(usize),
     ScreenshotGallery(bool),
     ScreenshotGalleryPrev,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1192,7 +1192,7 @@ impl App {
     fn queue_previews(results: &[SearchResult], count: usize) {
         for result in results.iter().take(count) {
             if let Some(screenshot) = result.info.screenshots.first() {
-                preview_cache::queue(&screenshot.url);
+                preview_cache::queue(&screenshot.url, result.info.version());
             }
         }
     }
@@ -2968,18 +2968,22 @@ impl Application for App {
         }
 
         if let Some(selected) = &self.selected_opt {
+            let version = selected.info.version().to_string();
             for (screenshot_i, screenshot) in selected.info.screenshots.iter().enumerate() {
                 let url = screenshot.url.clone();
+                let version = version.clone();
                 subscriptions.push(Subscription::run_with(
-                    (screenshot_i, url.clone()),
-                    |(screenshot_i, url)| {
+                    // Key on version too so an app update restarts the fetch
+                    (screenshot_i, url.clone(), version.clone()),
+                    move |(screenshot_i, url, version)| {
                         let screenshot_i = *screenshot_i;
                         let url = url.clone();
+                        let version = version.clone();
                         stream::channel(
                             16,
                             move |mut msg_tx: futures::channel::mpsc::Sender<Message>| async move {
                                 // Check cache first
-                                if let Some(data) = preview_cache::get_cached(&url) {
+                                if let Some(data) = preview_cache::get_cached(&url, &version) {
                                     log::debug!("screenshot cache hit: {}", url);
                                     let _ = msg_tx
                                         .send(Message::SelectedScreenshot(screenshot_i, url, data))
@@ -2993,7 +2997,9 @@ impl Application for App {
                                         Ok(bytes) => {
                                             let data = bytes.to_vec();
                                             // Save to cache
-                                            if let Err(e) = preview_cache::save_to_cache(&url, &data) {
+                                            if let Err(e) =
+                                                preview_cache::save_to_cache(&url, &version, &data)
+                                            {
                                                 log::warn!("failed to cache screenshot {}: {}", url, e);
                                             }
                                             let _ = msg_tx
@@ -3032,13 +3038,13 @@ impl Application for App {
                 let mut bytes_since_limit_check: u64 = 0;
                 loop {
                     preview_cache::wait_for_work().await;
-                    let urls = preview_cache::take_pending();
-                    for url in &urls {
+                    let pending = preview_cache::take_pending();
+                    for (url, version) in &pending {
                         log::debug!("preview fetch: {}", url);
                         if let Ok(resp) = reqwest::get(url).await {
                             if let Ok(bytes) = resp.bytes().await {
                                 bytes_since_limit_check += bytes.len() as u64;
-                                let _ = preview_cache::save_to_cache(url, &bytes);
+                                let _ = preview_cache::save_to_cache(url, version, &bytes);
                             }
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,9 @@ pub enum Message {
     SelectedAddonsViewMore(bool),
     SelectedScreenshot(usize, String, Vec<u8>),
     SelectedScreenshotShown(usize),
+    ScreenshotGallery(bool),
+    ScreenshotGalleryPrev,
+    ScreenshotGalleryNext,
     ToggleUninstallPurgeData(bool),
     SelectedSource(usize),
     SystemThemeModeChange(cosmic_theme::ThemeMode),
@@ -409,6 +412,7 @@ pub struct Selected {
     pub info: Arc<AppInfo>,
     pub screenshot_images: HashMap<usize, widget::image::Handle>,
     pub screenshot_shown: usize,
+    pub screenshot_gallery: bool,
     pub sources: Vec<SelectedSource>,
     pub addons: Vec<(AppId, Arc<AppInfo>)>,
     pub addons_view_more: bool,
@@ -1121,6 +1125,7 @@ impl App {
             info,
             screenshot_images: HashMap::new(),
             screenshot_shown: 0,
+            screenshot_gallery: false,
             sources,
             addons,
             addons_view_more: false,
@@ -2144,6 +2149,13 @@ impl Application for App {
     }
 
     fn on_escape(&mut self) -> Task<Message> {
+        // Close the screenshot gallery first if it is open
+        if let Some(selected) = &mut self.selected_opt
+            && selected.screenshot_gallery
+        {
+            selected.screenshot_gallery = false;
+            return Task::none();
+        }
         if self.core.window.show_context {
             // Close context drawer if open
             self.core.window.show_context = false;
@@ -2224,6 +2236,11 @@ impl Application for App {
     }
 
     fn dialog(&self) -> Option<Element<'_, Message>> {
+        // Screenshot gallery overlay takes precedence over other dialogs
+        if let Some(gallery) = self.screenshot_gallery_view() {
+            return Some(gallery);
+        }
+
         let dialog_page = self.dialog_pages.front()?;
 
         let dialog = match dialog_page {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,13 +79,15 @@ mod priority;
 
 mod stats;
 
+mod preview_cache;
+
 use explore::ExplorePage;
 mod explore;
 
 use nav::{Category, CategoryIndex, NavPage, ScrollContext};
 mod nav;
 
-use search::{CachedExploreResults, SearchResult};
+use search::{CachedExploreResults, GridMetrics, SearchResult};
 mod search;
 
 mod view;
@@ -357,6 +359,7 @@ pub enum Message {
     WindowNew,
     SelectPlacement(cosmic::widget::segmented_button::Entity),
     PlaceApplet(AppId),
+    PreviewTick,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1116,6 +1119,7 @@ impl App {
             backend_name,
             info.source_id
         );
+
         let sources = self.selected_sources(backend_name, &id, &info);
         let addons = self.selected_addons(backend_name, &id, &info);
         self.selected_opt = Some(Selected {
@@ -1179,6 +1183,81 @@ impl App {
                     Message::BackendUpdateFinished
                 })),
         )
+    }
+
+    /// Queue preview images for first N items
+    fn queue_previews(results: &[SearchResult], count: usize) {
+        for result in results.iter().take(count) {
+            if let Some(screenshot) = result.info.screenshots.first() {
+                preview_cache::queue(&screenshot.url);
+            }
+        }
+    }
+
+    /// Calculate max results per explore section based on grid columns
+    fn explore_section_max_results(cols: usize) -> usize {
+        match cols {
+            1 => 4,
+            2 => 8,
+            3 => 9,
+            _ => cols * 2,
+        }
+    }
+
+    /// Calculate grid width from window size
+    fn grid_width(&self, spacing: &cosmic_theme::Spacing) -> usize {
+        self.size
+            .get()
+            .map(|s| (s.width - 2.0 * spacing.space_s as f32).floor().max(0.0) as usize)
+            .unwrap_or(800)
+    }
+
+    /// Queue preview images for explore page sections
+    fn queue_explore_previews(&self) {
+        let spacing = theme::active().cosmic().spacing;
+        let GridMetrics { cols, .. } =
+            SearchResult::grid_metrics(&spacing, self.grid_width(&spacing));
+
+        for results in self.explore_results.values() {
+            Self::queue_previews(results, Self::explore_section_max_results(cols));
+        }
+    }
+
+    /// Queue preview images for items visible in the scroll viewport
+    fn queue_visible_previews(&self, viewport: Option<&scrollable::Viewport>) {
+        let Some(results) = self.current_results() else {
+            return;
+        };
+
+        let spacing = theme::active().cosmic().spacing;
+        let GridMetrics { cols, .. } =
+            SearchResult::grid_metrics(&spacing, self.grid_width(&spacing));
+        let row_height = SearchResult::card_height(&spacing) + spacing.space_xxs as f32;
+
+        let (first_item, count) = match viewport {
+            Some(vp) => {
+                let first_row = (vp.absolute_offset().y / row_height).floor() as usize;
+                let visible_rows = (vp.bounds().height / row_height).ceil() as usize + 2;
+                (first_row * cols, visible_rows * cols)
+            }
+            None => (0, cols * 4), // Initial load: first ~4 rows
+        };
+
+        Self::queue_previews(&results[first_item.min(results.len())..], count);
+    }
+
+    /// Get the current results being displayed based on app state
+    fn current_results(&self) -> Option<&[SearchResult]> {
+        match (
+            &self.search_results,
+            self.explore_page_opt,
+            &self.category_results,
+        ) {
+            (Some((_, r)), _, _) => Some(r),
+            (None, Some(page), _) => self.explore_results.get(&page).map(|r| r.as_slice()),
+            (None, None, Some((_, r))) => Some(r),
+            _ => None,
+        }
     }
 
     fn update_config(&mut self) -> Task<Message> {
@@ -2090,6 +2169,8 @@ impl Application for App {
         let cache_start = Instant::now();
         if let Some(cached) = CachedExploreResults::load() {
             app.explore_results = cached.to_results();
+            // Queue preview images for all explore sections
+            app.queue_explore_previews();
             log::info!(
                 "explore page loaded from cache: {} categories in {:?}",
                 app.explore_results.len(),
@@ -2110,7 +2191,19 @@ impl Application for App {
             }
         }
 
-        let command = Task::batch([app.update_title(), app.update_backends(false)]);
+        let command = Task::batch([
+            app.update_title(),
+            app.update_backends(false),
+            // Run one-time preview cache cleanup in background
+            Task::perform(
+                async {
+                    tokio::task::spawn_blocking(preview_cache::enforce_size_limit)
+                        .await
+                        .ok();
+                },
+                |()| action::none(),
+            ),
+        ]);
         (app, command)
     }
 
@@ -2698,6 +2791,12 @@ impl Application for App {
                 .push(cosmic::iced::time::every(duration).map(|_| Message::PeriodicUpdateCheck));
         }
 
+        // Periodically queue preview images for visible items (catches scrollbar drag, etc.)
+        subscriptions.push(
+            cosmic::iced::time::every(std::time::Duration::from_millis(250))
+                .map(|_| Message::PreviewTick),
+        );
+
         if !self.pending_operations.is_empty() {
             #[cfg(feature = "logind")]
             {
@@ -2876,21 +2975,27 @@ impl Application for App {
                         stream::channel(
                             16,
                             move |mut msg_tx: futures::channel::mpsc::Sender<Message>| async move {
-                                log::info!("fetch screenshot {}", url);
+                                // Check cache first
+                                if let Some(data) = preview_cache::get_cached(&url) {
+                                    log::debug!("screenshot cache hit: {}", url);
+                                    let _ = msg_tx
+                                        .send(Message::SelectedScreenshot(screenshot_i, url, data))
+                                        .await;
+                                    return pending().await;
+                                }
+
+                                log::debug!("screenshot fetch: {}", url);
                                 match reqwest::get(&url).await {
                                     Ok(response) => match response.bytes().await {
                                         Ok(bytes) => {
-                                            log::info!(
-                                                "fetched screenshot from {}: {} bytes",
-                                                url,
-                                                bytes.len()
-                                            );
+                                            let data = bytes.to_vec();
+                                            // Save to cache
+                                            if let Err(e) = preview_cache::save_to_cache(&url, &data) {
+                                                log::warn!("failed to cache screenshot {}: {}", url, e);
+                                            }
                                             let _ = msg_tx
-                                                .send(Message::SelectedScreenshot(
-                                                    screenshot_i,
-                                                    url.clone(),
-                                                    bytes.to_vec(),
-                                                ))
+                                                .send(Message::SelectedScreenshot(screenshot_i,
+                                                    url.clone(), data))
                                                 .await;
                                         }
                                         Err(err) => {
@@ -2916,6 +3021,31 @@ impl Application for App {
                 ));
             }
         }
+
+        // Background preview cache downloader - wakes on notification, processes LIFO queue
+        subscriptions.push(Subscription::run_with("preview-cache-downloader", |_id| {
+            stream::channel(1, |_| async {
+                const SIZE_LIMIT_INTERVAL: u64 = 10 * 1024 * 1024; // 10 MB
+                let mut bytes_since_limit_check: u64 = 0;
+                loop {
+                    preview_cache::wait_for_work().await;
+                    let urls = preview_cache::take_pending();
+                    for url in &urls {
+                        log::debug!("preview fetch: {}", url);
+                        if let Ok(resp) = reqwest::get(url).await {
+                            if let Ok(bytes) = resp.bytes().await {
+                                bytes_since_limit_check += bytes.len() as u64;
+                                let _ = preview_cache::save_to_cache(url, &bytes);
+                            }
+                        }
+                    }
+                    if bytes_since_limit_check >= SIZE_LIMIT_INTERVAL {
+                        preview_cache::enforce_size_limit();
+                        bytes_since_limit_check = 0;
+                    }
+                }
+            })
+        }));
 
         Subscription::batch(subscriptions)
     }

--- a/src/preview_cache.rs
+++ b/src/preview_cache.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+    time::SystemTime,
+};
+use tokio::sync::Notify;
+
+/// Maximum number of URLs to take from queue per tick
+const MAX_BATCH_SIZE: usize = 5;
+
+/// Maximum cache size in bytes (250 MB)
+const MAX_CACHE_BYTES: u64 = 250 * 1024 * 1024;
+
+/// Convert a URL to a cache file path using a hash
+fn url_to_path(url: &str) -> Option<PathBuf> {
+    let mut hasher = DefaultHasher::new();
+    url.hash(&mut hasher);
+    let hash = format!("{:016x}", hasher.finish());
+    dirs::cache_dir().map(|dir| dir.join("cosmic-store/previews").join(&hash))
+}
+
+/// Get cached image data from disk (returns None if not cached)
+pub fn get_cached(url: &str) -> Option<Vec<u8>> {
+    let path = url_to_path(url)?;
+    std::fs::read(&path).ok()
+}
+
+/// Save data to disk cache
+pub fn save_to_cache(url: &str, data: &[u8]) -> std::io::Result<()> {
+    let path = url_to_path(url)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no cache directory"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, data)
+}
+
+/// Global download queue (LIFO for prioritizing recently viewed items)
+static PENDING: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// Notification for waking the background downloader
+static NOTIFY: OnceLock<Notify> = OnceLock::new();
+
+fn notify() -> &'static Notify {
+    NOTIFY.get_or_init(Notify::new)
+}
+
+/// Queue a URL for background download if not already cached
+pub fn queue(url: &str) {
+    // Skip if already cached
+    if url_to_path(url).is_some_and(|p| p.exists()) {
+        return;
+    }
+    if let Ok(mut queue) = PENDING.lock() {
+        // Avoid duplicates (cheap linear scan since queue stays small)
+        if !queue.iter().any(|u| u == url) {
+            queue.push(url.to_string());
+            notify().notify_one();
+        }
+    }
+}
+
+/// Take URLs to download (LIFO order, up to MAX_BATCH_SIZE)
+pub fn take_pending() -> Vec<String> {
+    let Ok(mut queue) = PENDING.lock() else {
+        return Vec::new();
+    };
+    let start = queue.len().saturating_sub(MAX_BATCH_SIZE);
+    queue.split_off(start)
+}
+
+/// Wait for work to be queued. Returns immediately if work is already pending.
+pub async fn wait_for_work() {
+    // Check if there's already work pending
+    if PENDING.lock().map(|q| !q.is_empty()).unwrap_or(false) {
+        return;
+    }
+    notify().notified().await;
+}
+
+/// Evict least-recently-accessed entries until total cache size is within the limit.
+pub fn enforce_size_limit() {
+    let Some(cache_dir) = dirs::cache_dir().map(|d| d.join("cosmic-store/previews")) else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&cache_dir) else {
+        return;
+    };
+
+    // Collect all files with their size and access time
+    let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+    let mut total_size: u64 = 0;
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Ok(metadata) = path.metadata() else {
+            continue;
+        };
+        let size = metadata.len();
+        let accessed = metadata.accessed().unwrap_or(
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+        );
+        total_size += size;
+        files.push((path, size, accessed));
+    }
+
+    if total_size <= MAX_CACHE_BYTES {
+        return;
+    }
+
+    // Sort by access time ascending (oldest accessed first)
+    files.sort_by_key(|(_, _, accessed)| *accessed);
+
+    let mut evicted = 0usize;
+    for (path, size, _) in &files {
+        if total_size <= MAX_CACHE_BYTES {
+            break;
+        }
+        if std::fs::remove_file(path).is_ok() {
+            total_size -= size;
+            evicted += 1;
+        }
+    }
+    if evicted > 0 {
+        log::info!(
+            "preview cache: evicted {} files to stay within {} MB limit",
+            evicted,
+            MAX_CACHE_BYTES / (1024 * 1024)
+        );
+    }
+}

--- a/src/preview_cache.rs
+++ b/src/preview_cache.rs
@@ -14,23 +14,26 @@ const MAX_BATCH_SIZE: usize = 5;
 /// Maximum cache size in bytes (250 MB)
 const MAX_CACHE_BYTES: u64 = 250 * 1024 * 1024;
 
-/// Convert a URL to a cache file path using a hash
-fn url_to_path(url: &str) -> Option<PathBuf> {
+/// Convert a URL + app version to a cache file path using a hash. Including the
+/// version means a new app release gets a distinct key and refetches its
+/// screenshots instead of serving stale ones.
+fn url_to_path(url: &str, version: &str) -> Option<PathBuf> {
     let mut hasher = DefaultHasher::new();
     url.hash(&mut hasher);
+    version.hash(&mut hasher);
     let hash = format!("{:016x}", hasher.finish());
     dirs::cache_dir().map(|dir| dir.join("cosmic-store/previews").join(&hash))
 }
 
 /// Get cached image data from disk (returns None if not cached)
-pub fn get_cached(url: &str) -> Option<Vec<u8>> {
-    let path = url_to_path(url)?;
+pub fn get_cached(url: &str, version: &str) -> Option<Vec<u8>> {
+    let path = url_to_path(url, version)?;
     std::fs::read(&path).ok()
 }
 
 /// Save data to disk cache
-pub fn save_to_cache(url: &str, data: &[u8]) -> std::io::Result<()> {
-    let path = url_to_path(url)
+pub fn save_to_cache(url: &str, version: &str, data: &[u8]) -> std::io::Result<()> {
+    let path = url_to_path(url, version)
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no cache directory"))?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -38,8 +41,9 @@ pub fn save_to_cache(url: &str, data: &[u8]) -> std::io::Result<()> {
     std::fs::write(path, data)
 }
 
-/// Global download queue (LIFO for prioritizing recently viewed items)
-static PENDING: Mutex<Vec<String>> = Mutex::new(Vec::new());
+/// Global download queue of `(url, version)` (LIFO for prioritizing recently
+/// viewed items)
+static PENDING: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
 
 /// Notification for waking the background downloader
 static NOTIFY: OnceLock<Notify> = OnceLock::new();
@@ -48,23 +52,24 @@ fn notify() -> &'static Notify {
     NOTIFY.get_or_init(Notify::new)
 }
 
-/// Queue a URL for background download if not already cached
-pub fn queue(url: &str) {
+/// Queue a URL (for the given app version) for background download if not
+/// already cached
+pub fn queue(url: &str, version: &str) {
     // Skip if already cached
-    if url_to_path(url).is_some_and(|p| p.exists()) {
+    if url_to_path(url, version).is_some_and(|p| p.exists()) {
         return;
     }
     if let Ok(mut queue) = PENDING.lock() {
         // Avoid duplicates (cheap linear scan since queue stays small)
-        if !queue.iter().any(|u| u == url) {
-            queue.push(url.to_string());
+        if !queue.iter().any(|(u, v)| u == url && v == version) {
+            queue.push((url.to_string(), version.to_string()));
             notify().notify_one();
         }
     }
 }
 
-/// Take URLs to download (LIFO order, up to MAX_BATCH_SIZE)
-pub fn take_pending() -> Vec<String> {
+/// Take `(url, version)` pairs to download (LIFO order, up to MAX_BATCH_SIZE)
+pub fn take_pending() -> Vec<(String, String)> {
     let Ok(mut queue) = PENDING.lock() else {
         return Vec::new();
     };

--- a/src/screenshot_image.rs
+++ b/src/screenshot_image.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Off-thread decoding and downscaling of screenshot images.
+//!
+//! Adapted from cosmic-files' `large_image.rs`: raster screenshots are decoded
+//! to RGBA and downscaled (Lanczos3) to roughly the on-screen display size, so
+//! the UI thread never decodes a multi-megapixel PNG mid-frame when the gallery
+//! switches images.
+
+use std::io::Cursor;
+
+/// Decode at up to this multiple of the display size, so the image still looks
+/// crisp if the window grows a little or the GPU upscales slightly.
+const DISPLAY_SCALE_FACTOR: f32 = 1.5;
+
+fn calculate_target_dimensions(
+    image_width: u32,
+    image_height: u32,
+    display_width: u32,
+    display_height: u32,
+) -> Option<(u32, u32)> {
+    let target_width = (display_width as f32 * DISPLAY_SCALE_FACTOR) as u32;
+    let target_height = (display_height as f32 * DISPLAY_SCALE_FACTOR) as u32;
+
+    if target_width == 0 || target_height == 0 {
+        return None;
+    }
+    if image_width <= target_width && image_height <= target_height {
+        return None;
+    }
+
+    let image_aspect = image_width as f32 / image_height as f32;
+    let target_aspect = target_width as f32 / target_height as f32;
+
+    let (new_width, new_height) = if image_aspect > target_aspect {
+        (target_width, (target_width as f32 / image_aspect) as u32)
+    } else {
+        ((target_height as f32 * image_aspect) as u32, target_height)
+    };
+
+    Some((new_width.max(1), new_height.max(1)))
+}
+
+pub fn decode_scaled(
+    data: &[u8],
+    display_width: u32,
+    display_height: u32,
+) -> Option<(u32, u32, Vec<u8>)> {
+    let reader = image::ImageReader::new(Cursor::new(data))
+        .with_guessed_format()
+        .ok()?;
+    let img = reader.decode().ok()?;
+    let rgba = img.into_rgba8();
+    let (orig_width, orig_height) = (rgba.width(), rgba.height());
+
+    match calculate_target_dimensions(orig_width, orig_height, display_width, display_height) {
+        Some((target_w, target_h)) => {
+            // Lanczos3 for high-quality downsampling
+            let resized = image::imageops::resize(
+                &rgba,
+                target_w,
+                target_h,
+                image::imageops::FilterType::Lanczos3,
+            );
+            let (w, h) = (resized.width(), resized.height());
+            Some((w, h, resized.into_raw()))
+        }
+        None => Some((orig_width, orig_height, rgba.into_raw())),
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -231,6 +231,11 @@ impl SearchResult {
         GridMetrics::new(width, 240 + 2 * spacing.space_s as usize, spacing.space_xxs)
     }
 
+    /// Card height including padding
+    pub fn card_height(spacing: &cosmic_theme::Spacing) -> f32 {
+        48.0 + (spacing.space_xxs as f32) * 2.0
+    }
+
     pub fn grid_view<'a, F: Fn(usize) -> Message + 'a>(
         results: &'a [Self],
         spacing: cosmic_theme::Spacing,
@@ -291,7 +296,7 @@ impl SearchResult {
         )
         .align_y(Alignment::Center)
         .width(Length::Fixed(width as f32))
-        .height(Length::Fixed(48.0 + (spacing.space_xxs as f32) * 2.0))
+        .height(Length::Fixed(Self::card_height(spacing)))
         .padding([spacing.space_xxs, spacing.space_s])
         .class(theme::Container::Card)
         .into()

--- a/src/update.rs
+++ b/src/update.rs
@@ -350,6 +350,30 @@ impl App {
                 }
             }
             Message::Key(modifiers, key, text) => {
+                // Handle screenshot gallery navigation/close while it is open
+                if self
+                    .selected_opt
+                    .as_ref()
+                    .is_some_and(|selected| selected.screenshot_gallery)
+                    && !modifiers.logo()
+                    && !modifiers.control()
+                    && !modifiers.alt()
+                    && !modifiers.shift()
+                {
+                    match key {
+                        Key::Named(key::Named::Escape) => {
+                            return self.handle_update(Message::ScreenshotGallery(false));
+                        }
+                        Key::Named(key::Named::ArrowLeft | key::Named::ArrowUp) => {
+                            return self.handle_update(Message::ScreenshotGalleryPrev);
+                        }
+                        Key::Named(key::Named::ArrowRight | key::Named::ArrowDown) => {
+                            return self.handle_update(Message::ScreenshotGalleryNext);
+                        }
+                        _ => {}
+                    }
+                }
+
                 // Handle ESC key to close dialogs
                 if !self.dialog_pages.is_empty()
                     && matches!(key, Key::Named(key::Named::Escape))
@@ -800,6 +824,31 @@ impl App {
             Message::SelectedScreenshotShown(i) => {
                 if let Some(selected) = &mut self.selected_opt {
                     selected.screenshot_shown = i;
+                }
+            }
+            Message::ScreenshotGallery(open) => {
+                if let Some(selected) = &mut self.selected_opt {
+                    // Only open the gallery when there is a screenshot to show
+                    selected.screenshot_gallery = open && !selected.info.screenshots.is_empty();
+                }
+            }
+            Message::ScreenshotGalleryPrev => {
+                if let Some(selected) = &mut self.selected_opt {
+                    let len = selected.info.screenshots.len();
+                    if len > 0 {
+                        selected.screenshot_shown = selected
+                            .screenshot_shown
+                            .checked_sub(1)
+                            .unwrap_or(len - 1);
+                    }
+                }
+            }
+            Message::ScreenshotGalleryNext => {
+                if let Some(selected) = &mut self.selected_opt {
+                    let len = selected.info.screenshots.len();
+                    if len > 0 {
+                        selected.screenshot_shown = (selected.screenshot_shown + 1) % len;
+                    }
                 }
             }
             Message::ToggleUninstallPurgeData(value) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -823,13 +823,48 @@ impl App {
                 }
             }
             Message::SelectedScreenshot(i, url, data) => {
+                // Only decode if this screenshot still belongs to the current selection
+                let matches = self.selected_opt.as_ref().is_some_and(|selected| {
+                    selected
+                        .info
+                        .screenshots
+                        .get(i)
+                        .is_some_and(|screenshot| screenshot.url == url)
+                });
+                if matches {
+                    // Decode + downscale off the UI thread to the display size so
+                    // switching gallery images doesn't stall on a full-res decode.
+                    let (display_w, display_h) = self
+                        .size
+                        .get()
+                        .map(|size| (size.width as u32, size.height as u32))
+                        .unwrap_or((1920, 1080));
+                    return Task::perform(
+                        async move {
+                            tokio::task::spawn_blocking(move || {
+                                crate::screenshot_image::decode_scaled(&data, display_w, display_h)
+                                    .map(|(w, h, rgba)| {
+                                        action::app(Message::SelectedScreenshotDecoded(
+                                            i, url, w, h, rgba,
+                                        ))
+                                    })
+                                    .unwrap_or(action::none())
+                            })
+                            .await
+                            .unwrap_or(action::none())
+                        },
+                        |x| x,
+                    );
+                }
+            }
+            Message::SelectedScreenshotDecoded(i, url, width, height, rgba) => {
                 if let Some(selected) = &mut self.selected_opt
                     && let Some(screenshot) = selected.info.screenshots.get(i)
                     && screenshot.url == url
                 {
                     selected
                         .screenshot_images
-                        .insert(i, widget::image::Handle::from_bytes(data));
+                        .insert(i, widget::image::Handle::from_rgba(width, height, rgba));
                 }
             }
             Message::SelectedScreenshotShown(i) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -108,7 +108,8 @@ impl App {
                     preserve_icons_from(old_results, &mut results);
                 }
                 self.category_results = Some((categories, results));
-                // Load icons in background
+                // Queue initial preview images
+                self.queue_visible_previews(None);
                 return Task::batch([self.update_scroll(), self.load_category_icons(categories)]);
             }
             Message::CategoryIconsLoaded(categories, icons) => {
@@ -171,6 +172,8 @@ impl App {
             }
             Message::ExplorePage(explore_page_opt) => {
                 self.explore_page_opt = explore_page_opt;
+                // Queue initial preview images
+                self.queue_visible_previews(None);
                 return self.update_scroll();
             }
             Message::AllExploreResults(mut all_results, cached) => {
@@ -185,6 +188,9 @@ impl App {
                         tasks.push(self.load_explore_icons(explore_page));
                     }
                 }
+
+                // Queue preview images for all explore sections
+                self.queue_explore_previews();
 
                 // Save pre-built cache in background
                 rayon::spawn(move || {
@@ -596,6 +602,10 @@ impl App {
             Message::ScrollView(viewport) => {
                 self.scroll_views.insert(self.scroll_context(), viewport);
             }
+            Message::PreviewTick => {
+                let viewport = self.scroll_views.get(&self.scroll_context()).copied();
+                self.queue_visible_previews(viewport.as_ref());
+            }
             Message::SearchActivate => {
                 self.search_active = true;
                 return widget::text_input::focus(self.search_id.clone());
@@ -682,8 +692,9 @@ impl App {
                         }
                     }
                     self.search_results = Some((input.clone(), results));
+                    // Queue initial preview images
+                    self.queue_visible_previews(None);
                     tasks.push(self.update_scroll());
-                    // Load icons in background
                     tasks.push(self.load_search_icons(input));
                     return Task::batch(tasks);
                 } else {

--- a/src/view.rs
+++ b/src/view.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use cosmic::{
     Apply, Element, cosmic_theme,
-    iced::{Alignment, Length, Size},
+    iced::{Alignment, Color, Length, Size},
     theme, widget,
 };
 use rayon::prelude::*;
@@ -347,6 +347,105 @@ impl App {
         .into()
     }
 
+    /// Full-screen overlay showing an enlarged screenshot with prev/next navigation.
+    /// `dialog()` calls this when `Selected::screenshot_gallery` is set. Reuses the
+    /// handles already downloaded into `Selected::screenshot_images`.
+    pub fn screenshot_gallery_view(&self) -> Option<Element<'_, Message>> {
+        let selected = self.selected_opt.as_ref()?;
+        if !selected.screenshot_gallery {
+            return None;
+        }
+        let screenshots = &selected.info.screenshots;
+        let screenshot = screenshots.get(selected.screenshot_shown)?;
+        let spacing = theme::active().cosmic().spacing;
+        let space_m = Length::Fixed(spacing.space_m.into());
+
+        let mut column = widget::column::with_capacity(2).spacing(spacing.space_s);
+
+        // Header row: caption + close button
+        {
+            let mut row = widget::row::with_capacity(3).align_y(Alignment::Center);
+            row = row.push(widget::space::horizontal());
+            if !screenshot.caption.is_empty() {
+                row = row.push(widget::text::heading(&screenshot.caption));
+            }
+            row = row.push(widget::space::horizontal());
+            row = row.push(
+                widget::button::icon(
+                    widget::icon::from_name("window-close-symbolic").size(16),
+                )
+                .class(theme::Button::Standard)
+                .on_press(Message::ScreenshotGallery(false)),
+            );
+            column = column.push(row);
+        }
+
+        // Navigation + image row: prev button | image | next button
+        {
+            let has_multiple = screenshots.len() > 1;
+            let mut row = widget::row::with_capacity(5).align_y(Alignment::Center);
+            row = row.push(widget::space::horizontal().width(space_m));
+            {
+                let mut button = widget::button::icon(
+                    widget::icon::from_name("go-previous-symbolic").size(16),
+                )
+                .padding(spacing.space_xs)
+                .class(theme::Button::Standard);
+                if has_multiple {
+                    button = button.on_press(Message::ScreenshotGalleryPrev);
+                }
+                row = row.push(button);
+            }
+            let image_element: Element<'_, Message> =
+                if let Some(image) = selected.screenshot_images.get(&selected.screenshot_shown) {
+                    // Scale up to fill the available space, preserving aspect ratio
+                    widget::container(
+                        widget::image(image.clone())
+                            .width(Length::Fill)
+                            .height(Length::Fill),
+                    )
+                    .center_x(Length::Fill)
+                    .center_y(Length::Fill)
+                    .into()
+                } else {
+                    widget::container(widget::text::body(fl!("loading")))
+                        .center_x(Length::Fill)
+                        .center_y(Length::Fill)
+                        .into()
+                };
+            row = row.push(image_element);
+            {
+                let mut button = widget::button::icon(
+                    widget::icon::from_name("go-next-symbolic").size(16),
+                )
+                .padding(spacing.space_xs)
+                .class(theme::Button::Standard);
+                if has_multiple {
+                    button = button.on_press(Message::ScreenshotGalleryNext);
+                }
+                row = row.push(button);
+            }
+            row = row.push(widget::space::horizontal().width(space_m));
+            column = column.push(row.height(Length::Fill));
+        }
+
+        Some(
+            widget::container(column.padding(spacing.space_m))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .class(theme::Container::custom(|theme| {
+                    let cosmic = theme.cosmic();
+                    let mut bg = cosmic.bg_color();
+                    bg.alpha = 0.9;
+                    widget::container::Style {
+                        background: Some(Color::from(bg).into()),
+                        ..Default::default()
+                    }
+                }))
+                .into(),
+        )
+    }
+
     pub fn view_responsive(&self, size: Size) -> Element<'_, Message> {
         self.size.set(Some(size));
         let spacing = theme::active().cosmic().spacing;
@@ -506,10 +605,13 @@ impl App {
                     let image_element = if let Some(image) =
                         selected.screenshot_images.get(&selected.screenshot_shown)
                     {
-                        widget::container(widget::image(image.clone()))
-                            .center_x(Length::Fill)
-                            .center_y(image_height)
-                            .into()
+                        widget::mouse_area(
+                            widget::container(widget::image(image.clone()))
+                                .center_x(Length::Fill)
+                                .center_y(image_height),
+                        )
+                        .on_press(Message::ScreenshotGallery(true))
+                        .into()
                     } else {
                         widget::space::horizontal()
                             .width(Length::Fill)

--- a/src/view.rs
+++ b/src/view.rs
@@ -385,16 +385,15 @@ impl App {
             let has_multiple = screenshots.len() > 1;
             let mut row = widget::row::with_capacity(5).align_y(Alignment::Center);
             row = row.push(widget::space::horizontal().width(space_m));
-            {
-                let mut button = widget::button::icon(
-                    widget::icon::from_name("go-previous-symbolic").size(16),
-                )
-                .padding(spacing.space_xs)
-                .class(theme::Button::Standard);
-                if has_multiple {
-                    button = button.on_press(Message::ScreenshotGalleryPrev);
-                }
-                row = row.push(button);
+            if has_multiple {
+                row = row.push(
+                    widget::button::icon(
+                        widget::icon::from_name("go-previous-symbolic").size(16),
+                    )
+                    .padding(spacing.space_xs)
+                    .class(theme::Button::Standard)
+                    .on_press(Message::ScreenshotGalleryPrev),
+                );
             }
             let image_element: Element<'_, Message> =
                 if let Some(image) = selected.screenshot_images.get(&selected.screenshot_shown) {
@@ -414,16 +413,15 @@ impl App {
                         .into()
                 };
             row = row.push(image_element);
-            {
-                let mut button = widget::button::icon(
-                    widget::icon::from_name("go-next-symbolic").size(16),
-                )
-                .padding(spacing.space_xs)
-                .class(theme::Button::Standard);
-                if has_multiple {
-                    button = button.on_press(Message::ScreenshotGalleryNext);
-                }
-                row = row.push(button);
+            if has_multiple {
+                row = row.push(
+                    widget::button::icon(
+                        widget::icon::from_name("go-next-symbolic").size(16),
+                    )
+                    .padding(spacing.space_xs)
+                    .class(theme::Button::Standard)
+                    .on_press(Message::ScreenshotGalleryNext),
+                );
             }
             row = row.push(widget::space::horizontal().width(space_m));
             column = column.push(row.height(Length::Fill));
@@ -588,8 +586,9 @@ impl App {
                 //TODO: proper image scroller
                 if let Some(screenshot) = selected.info.screenshots.get(selected.screenshot_shown) {
                     let image_height = Length::Fixed(320.0);
+                    let has_multiple = selected.info.screenshots.len() > 1;
                     let mut row = widget::row::with_capacity(3).align_y(Alignment::Center);
-                    {
+                    if has_multiple {
                         let mut button = widget::button::icon(
                             widget::icon::from_name("go-previous-symbolic").size(16),
                         );
@@ -625,7 +624,7 @@ impl App {
                         ])
                         .align_x(Alignment::Center),
                     );
-                    {
+                    if has_multiple {
                         let mut button = widget::button::icon(
                             widget::icon::from_name("go-next-symbolic").size(16),
                         );

--- a/src/view.rs
+++ b/src/view.rs
@@ -872,14 +872,8 @@ impl App {
                                             let GridMetrics { cols, .. } =
                                                 SearchResult::grid_metrics(&spacing, grid_width);
 
-                                            let max_results = match cols {
-                                                1 => 4,
-                                                2 => 8,
-                                                3 => 9,
-                                                _ => cols * 2,
-                                            };
-
-                                            //TODO: adjust results length based on app size?
+                                            let max_results =
+                                                Self::explore_section_max_results(cols);
                                             let results_len = cmp::min(results.len(), max_results);
 
                                             column = column.push(widget::row::with_children(vec![


### PR DESCRIPTION
This pulls in gallery mode and large image decode offloading from cosmic-files, and the image cache from https://github.com/pop-os/cosmic-store/pull/456. Image cache is limited to 250mb max (from @FreddyFunk's PR), I only changed the cache-key to take app version into account.

- you can enlarge an image by clicking on it (gallery view)
- caches the images, so it's faster next time
- caches using image url and app version, so refetches images on app update
- removed the next/prev buttons if there's only one image


https://github.com/user-attachments/assets/6db1d9ae-4eae-4a9b-863a-2b98f7efe3d2


This looks like a big PR, but it's mostly either from cosmic-files, or from Freddy's PR.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

