### PR TITLE
Offer to update when a package file is newer than what is installed

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,7 @@ This document provides a regression testing checklist for the COSMIC Store. The 
 - [ ] Able to install & remove a Flatpak app.
 - [ ] Able to install & remove a Deb app.
 - [ ] Able to install Deb updates.
+- [ ] Opening a Deb or RPM file that is newer than the installed package offers to update it.
 - [ ] Searching still works.
 - [ ] Browsing categories still works.
 - [ ] Able to remove & re-add Flatpak sources.

--- a/res/com.system76.CosmicStore.metainfo.xml
+++ b/res/com.system76.CosmicStore.metainfo.xml
@@ -39,6 +39,7 @@
     <mimetypes>
         <mimetype>application/x-debian-package</mimetype>
         <mimetype>application/vnd.debian.binary-package</mimetype>
+        <mimetype>application/x-rpm</mimetype>
         <mimetype>application/vnd.flatpak.ref</mimetype>
     </mimetypes>
   </provides>

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -86,6 +86,13 @@ pub trait Backend: fmt::Debug + Send + Sync {
     fn installed(&self) -> Result<Vec<Package>, Box<dyn Error>>;
     fn updates(&self) -> Result<Vec<Package>, Box<dyn Error>>;
     fn file_packages(&self, path: &str) -> Result<Vec<Package>, Box<dyn Error>>;
+    /// Version of `package` that is currently installed, if any.
+    ///
+    /// This is used to find out if a package loaded with
+    /// [`Backend::file_packages`] provides an update for an installed package.
+    fn installed_version(&self, _package: &Package) -> Option<String> {
+        None
+    }
     fn gstreamer_packages(
         &self,
         _gstreamer_codec: &GStreamerCodec,

--- a/src/backend/packagekit.rs
+++ b/src/backend/packagekit.rs
@@ -181,6 +181,27 @@ impl Packagekit {
         Ok(tx)
     }
 
+    /// Installed version of the first of `package_names` that is installed.
+    ///
+    /// The same package can be installed for more than one architecture, in
+    /// which case the versions are expected to match.
+    fn resolve_installed_version(
+        &self,
+        package_names: &[&str],
+    ) -> Result<Option<String>, Box<dyn Error>> {
+        let tx = self.transaction()?;
+        tx.resolve(FilterKind::Installed as u64, package_names)?;
+        let (_tx_details, tx_packages) = transaction_handle(tx, |_, _| {})?;
+        Ok(tx_packages.iter().find_map(|tx_package| {
+            let mut parts = tx_package.package_id.split(';');
+            let package_name = parts.next()?;
+            let version = parts.next()?;
+            package_names
+                .contains(&package_name)
+                .then(|| version.to_string())
+        }))
+    }
+
     fn package_transaction(
         &self,
         tx: TransactionProxyBlocking,
@@ -383,6 +404,31 @@ impl Backend for Packagekit {
         Ok(packages)
     }
 
+    fn installed_version(&self, package: &Package) -> Option<String> {
+        let package_names: Vec<&str> = package
+            .info
+            .pkgnames
+            .iter()
+            .map(|pkgname| pkgname.as_str())
+            .collect();
+        if package_names.is_empty() {
+            return None;
+        }
+        match self.resolve_installed_version(&package_names) {
+            Ok(version_opt) => version_opt,
+            Err(err) => {
+                // A package that is not installed is not an error here, so this
+                // is only worth logging
+                log::debug!(
+                    "failed to resolve installed version of {:?}: {}",
+                    package_names,
+                    err
+                );
+                None
+            }
+        }
+    }
+
     fn gstreamer_packages(
         &self,
         gstreamer_codec: &GStreamerCodec,
@@ -428,7 +474,14 @@ impl Backend for Packagekit {
         if package_names.is_empty() {
             return Err(format!("{:?} missing package name", op.package_ids).into());
         }
-        let (_tx_details, tx_packages) = {
+        // Package files provide everything that is required to install or update,
+        // and the packages they contain may not be in any repository, so there is
+        // nothing to resolve in that case
+        let use_package_paths = !package_paths.is_empty()
+            && matches!(op.kind, OperationKind::Install | OperationKind::Update);
+        let (_tx_details, tx_packages) = if use_package_paths {
+            (Vec::new(), Vec::new())
+        } else {
             let tx = self.transaction()?;
             log::info!("resolve packages for {:?}", package_names);
             let filter = match &op.kind {
@@ -452,7 +505,7 @@ impl Backend for Packagekit {
         tx.set_hints(&["interactive=true"])?;
         match &op.kind {
             OperationKind::Install => {
-                if !package_paths.is_empty() {
+                if use_package_paths {
                     log::info!("installing package files {:?}", package_paths);
                     //TODO: transaction flags
                     tx.install_files(0, &package_paths)?;
@@ -480,9 +533,17 @@ impl Backend for Packagekit {
                 tx.remove_packages(0, &package_ids, true, true)?;
             }
             OperationKind::Update => {
-                log::info!("updating packages {:?}", package_ids);
-                //TODO: transaction flags?
-                tx.update_packages(TransactionFlag::OnlyTrusted as u64, &package_ids)?;
+                if use_package_paths {
+                    // Installing a package file that contains a newer version
+                    // updates the installed package, like `apt install ./file.deb`
+                    log::info!("updating from package files {:?}", package_paths);
+                    //TODO: transaction flags
+                    tx.install_files(0, &package_paths)?;
+                } else {
+                    log::info!("updating packages {:?}", package_ids);
+                    //TODO: transaction flags?
+                    tx.update_packages(TransactionFlag::OnlyTrusted as u64, &package_ids)?;
+                }
             }
             OperationKind::RepositoryAdd { .. } => {
                 return Err("packagekit backend does not support adding repositories".into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,8 @@ mod nav;
 use search::{CachedExploreResults, SearchResult};
 mod search;
 
+mod version;
+
 mod view;
 
 mod update;
@@ -297,6 +299,9 @@ pub enum Message {
         CachedExploreResults,
     ),
     ExploreIconsLoaded(ExplorePage, Vec<(usize, widget::icon::Handle)>),
+    /// Packages found in a local package file, along with the versions needed
+    /// to tell if the file is an update
+    FilePackages(String, Vec<FilePackage>),
     GStreamerExit(GStreamerExitCode),
     GStreamerInstall,
     GStreamerToggle(usize),
@@ -371,6 +376,24 @@ pub enum DialogPage {
     RepositoryRemove(BackendName, RepositoryRemoveError),
     Uninstall(BackendName, AppId, Arc<AppInfo>),
     Place(AppId),
+}
+
+/// A package loaded from a local package file, such as a `.deb`
+#[derive(Clone, Debug)]
+pub struct FilePackage {
+    pub backend_name: BackendName,
+    pub package: Package,
+    /// Version of this package that is currently installed, if any
+    pub installed_version_opt: Option<String>,
+}
+
+/// Versions of a package that was loaded from a local package file
+#[derive(Clone, Debug)]
+pub struct FileVersions {
+    /// Version provided by the package file
+    pub file: String,
+    /// Version that was installed when the file was loaded, if any
+    pub installed_opt: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -454,6 +477,8 @@ pub struct App {
     pub waiting_updates: Vec<(BackendName, String, AppId)>,
     pub category_results: Option<(&'static [Category], Vec<SearchResult>)>,
     pub category_load_start: Option<Instant>,
+    /// Versions of packages loaded from local package files, keyed by backend and package ID
+    pub file_versions: HashMap<(BackendName, AppId), FileVersions>,
     pub explore_results: HashMap<ExplorePage, Vec<SearchResult>>,
     pub explore_results_handle: Option<(Arc<atomic::AtomicBool>, cosmic::iced::task::Handle)>,
     pub installed_results: Option<Vec<SearchResult>>,
@@ -1220,6 +1245,29 @@ impl App {
         Self::is_installed_inner(&self.installed, backend_name, id, info)
     }
 
+    /// Check if a package loaded from a local package file provides a newer
+    /// version than the one that is installed
+    pub fn file_update_available(
+        &self,
+        backend_name: BackendName,
+        id: &AppId,
+        info: &AppInfo,
+    ) -> bool {
+        // The file decides how versions are ordered, as `.deb` and `.rpm` do
+        // not sort them the same way
+        let Some(package_path) = info.package_paths.first() else {
+            return false;
+        };
+        let Some(versions) = self.file_versions.get(&(backend_name, id.clone())) else {
+            return false;
+        };
+        let Some(installed) = &versions.installed_opt else {
+            return false;
+        };
+        version::Format::from_path(package_path).compare(&versions.file, installed)
+            == cmp::Ordering::Greater
+    }
+
     fn update_apps(&mut self) -> Task<Message> {
         self.update_apps_scheduled = false;
         self.update_apps_in_progress = true;
@@ -1508,12 +1556,20 @@ impl App {
             async move {
                 tokio::task::spawn_blocking(move || {
                     let start = Instant::now();
-                    let mut packages = Vec::new();
+                    let mut file_packages = Vec::new();
                     for (backend_name, backend) in backends.iter() {
                         match backend.file_packages(&path) {
                             Ok(backend_packages) => {
                                 for package in backend_packages {
-                                    packages.push((backend_name, package));
+                                    // Look up the installed version so that a file
+                                    // containing a newer version can be offered as
+                                    // an update
+                                    let installed_version_opt = backend.installed_version(&package);
+                                    file_packages.push(FilePackage {
+                                        backend_name: *backend_name,
+                                        package,
+                                        installed_version_opt,
+                                    });
                                 }
                             }
                             Err(err) => {
@@ -1531,21 +1587,10 @@ impl App {
                         "loaded file {:?} in {:?}, found {} packages",
                         path,
                         duration,
-                        packages.len()
+                        file_packages.len()
                     );
 
-                    //TODO: store the resolved packages somewhere
-                    let mut results = Vec::with_capacity(packages.len());
-                    for (backend_name, package) in packages {
-                        results.push(SearchResult {
-                            backend_name: *backend_name,
-                            id: package.id,
-                            icon_opt: Some(package.icon),
-                            info: package.info,
-                            weight: 0,
-                        });
-                    }
-                    action::app(Message::SearchResults(input, results, true))
+                    action::app(Message::FilePackages(input, file_packages))
                 })
                 .await
                 .unwrap_or(action::none())
@@ -2069,6 +2114,7 @@ impl Application for App {
             waiting_updates: Vec::new(),
             category_results: None,
             category_load_start: Some(Instant::now()),
+            file_versions: HashMap::new(),
             explore_results: HashMap::new(),
             explore_results_handle: None,
             installed_results: None,

--- a/src/update.rs
+++ b/src/update.rs
@@ -27,8 +27,8 @@ use crate::backend::BackendName;
 use crate::explore::ExplorePage;
 use crate::nav::NavPage;
 use crate::operation::{Operation, OperationKind, RepositoryAdd};
-use crate::search::{apply_icons_to_results, preserve_icons_from};
-use crate::{App, DialogPage, GStreamerExitCode, Message, Mode};
+use crate::search::{SearchResult, apply_icons_to_results, preserve_icons_from};
+use crate::{App, DialogPage, FileVersions, GStreamerExitCode, Message, Mode};
 
 impl App {
     pub fn handle_update(&mut self, message: Message) -> Task<Message> {
@@ -201,6 +201,31 @@ impl App {
                 if let Some(results) = self.explore_results.get_mut(&explore_page) {
                     apply_icons_to_results(results, icons);
                 }
+            }
+            Message::FilePackages(input, file_packages) => {
+                //TODO: store the resolved packages somewhere
+                let mut results = Vec::with_capacity(file_packages.len());
+                for file_package in file_packages {
+                    let backend_name = file_package.backend_name;
+                    let package = file_package.package;
+                    // Remember the versions so that the file can be offered as an
+                    // update when it is newer than the installed package
+                    self.file_versions.insert(
+                        (backend_name, package.id.clone()),
+                        FileVersions {
+                            file: package.version,
+                            installed_opt: file_package.installed_version_opt,
+                        },
+                    );
+                    results.push(SearchResult {
+                        backend_name,
+                        id: package.id,
+                        icon_opt: Some(package.icon),
+                        info: package.info,
+                        weight: 0,
+                    });
+                }
+                return self.handle_update(Message::SearchResults(input, results, true));
             }
             Message::GStreamerExit(code) => match self.mode {
                 Mode::Normal => {}
@@ -426,6 +451,10 @@ impl App {
                             info.source_id.clone(),
                             package_id.clone(),
                         ));
+                        // Versions found when a package file was loaded are out of
+                        // date once an operation on that package has finished
+                        self.file_versions
+                            .remove(&(op.backend_name, package_id.clone()));
                     }
                     self.complete_operations.insert(id, op);
                 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,405 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Comparison of package versions.
+//!
+//! Backends normally let the package manager decide what is an update, but a
+//! package loaded from a local file (such as a `.deb` or `.rpm` opened from a
+//! browser) has to be compared against the installed version by hand.
+//!
+//! Both formats use an `epoch:version-release` string, but they order the rest
+//! differently, so the ordering is picked from the file the package came from:
+//!
+//! * Debian policy
+//!   (<https://www.debian.org/doc/debian-policy/ch-controlfields.html#version>)
+//! * `rpmvercmp` from RPM
+//!   (<https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmvercmp.c>)
+
+use std::{cmp::Ordering, path::Path};
+
+/// Version ordering used by a package format
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Format {
+    /// Debian ordering, used for `.deb` packages
+    Deb,
+    /// RPM ordering, used for `.rpm` packages
+    Rpm,
+}
+
+impl Format {
+    /// Format of the package file at `path`.
+    ///
+    /// Anything that is not an RPM is compared with Debian ordering, which is
+    /// the only kind of package file the store has opened so far.
+    pub fn from_path(path: &str) -> Self {
+        match Path::new(path).extension().and_then(|ext| ext.to_str()) {
+            Some(ext) if ext.eq_ignore_ascii_case("rpm") => Self::Rpm,
+            _ => Self::Deb,
+        }
+    }
+
+    /// Compare two package versions
+    pub fn compare(self, a: &str, b: &str) -> Ordering {
+        let (a_epoch, a_version, a_release) = split(a);
+        let (b_epoch, b_version, b_release) = split(b);
+        let compare_part = match self {
+            Self::Deb => compare_part_deb,
+            Self::Rpm => compare_part_rpm,
+        };
+        a_epoch
+            .cmp(&b_epoch)
+            .then_with(|| compare_part(a_version, b_version))
+            .then_with(|| compare_part(a_release, b_release))
+    }
+}
+
+/// Split a version into its epoch, version, and release
+fn split(version: &str) -> (u64, &str, &str) {
+    let version = version.trim();
+    let (epoch, rest) = match version.split_once(':') {
+        // An unparsable epoch means this version does not have one
+        Some((epoch, rest)) => match epoch.parse::<u64>() {
+            Ok(epoch) => (epoch, rest),
+            Err(_) => (0, version),
+        },
+        None => (0, version),
+    };
+    match rest.rsplit_once('-') {
+        Some((version, release)) => (epoch, version, release),
+        None => (epoch, rest, ""),
+    }
+}
+
+/// Sort order of a single character of a non-digit part, following dpkg:
+/// `~` sorts before the end of a part, which sorts before letters, which sort
+/// before all other characters.
+fn order(c_opt: Option<u8>) -> i32 {
+    match c_opt {
+        Some(b'~') => -1,
+        None => 0,
+        Some(c) if c.is_ascii_digit() => 0,
+        Some(c) if c.is_ascii_alphabetic() => i32::from(c),
+        Some(c) => i32::from(c) + 256,
+    }
+}
+
+/// Compare the version or release part of two Debian versions
+fn compare_part_deb(a: &str, b: &str) -> Ordering {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (mut i, mut j) = (0, 0);
+    while i < a.len() || j < b.len() {
+        // Compare non-digit runs one character at a time
+        while (i < a.len() && !a[i].is_ascii_digit()) || (j < b.len() && !b[j].is_ascii_digit()) {
+            let a_order = order(a.get(i).copied());
+            let b_order = order(b.get(j).copied());
+            if a_order != b_order {
+                return a_order.cmp(&b_order);
+            }
+            i += 1;
+            j += 1;
+        }
+
+        // Compare digit runs numerically, which means ignoring leading zeros
+        // and treating the longer run as the larger number
+        while i < a.len() && a[i] == b'0' {
+            i += 1;
+        }
+        while j < b.len() && b[j] == b'0' {
+            j += 1;
+        }
+        let mut first_diff = Ordering::Equal;
+        while i < a.len() && j < b.len() && a[i].is_ascii_digit() && b[j].is_ascii_digit() {
+            if first_diff == Ordering::Equal {
+                first_diff = a[i].cmp(&b[j]);
+            }
+            i += 1;
+            j += 1;
+        }
+        if i < a.len() && a[i].is_ascii_digit() {
+            return Ordering::Greater;
+        }
+        if j < b.len() && b[j].is_ascii_digit() {
+            return Ordering::Less;
+        }
+        if first_diff != Ordering::Equal {
+            return first_diff;
+        }
+    }
+    Ordering::Equal
+}
+
+/// Characters between segments of an RPM version, which are not compared
+/// themselves
+fn is_separator(c: u8) -> bool {
+    !c.is_ascii_alphanumeric() && c != b'~' && c != b'^'
+}
+
+/// End of the alphabetic or numeric segment that starts at `i`
+fn segment_end(v: &[u8], mut i: usize, numeric: bool) -> usize {
+    while i < v.len()
+        && if numeric {
+            v[i].is_ascii_digit()
+        } else {
+            v[i].is_ascii_alphabetic()
+        }
+    {
+        i += 1;
+    }
+    i
+}
+
+/// Compare the version or release part of two RPM versions
+fn compare_part_rpm(a: &str, b: &str) -> Ordering {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (mut i, mut j) = (0, 0);
+    while i < a.len() || j < b.len() {
+        // Separators are not compared, only the segments around them
+        while i < a.len() && is_separator(a[i]) {
+            i += 1;
+        }
+        while j < b.len() && is_separator(b[j]) {
+            j += 1;
+        }
+
+        // `~` sorts before everything, including the end of a version
+        if a.get(i) == Some(&b'~') || b.get(j) == Some(&b'~') {
+            if a.get(i) != Some(&b'~') {
+                return Ordering::Greater;
+            }
+            if b.get(j) != Some(&b'~') {
+                return Ordering::Less;
+            }
+            i += 1;
+            j += 1;
+            continue;
+        }
+
+        // `^` sorts before everything as well, but after the end of a version
+        if a.get(i) == Some(&b'^') || b.get(j) == Some(&b'^') {
+            if i >= a.len() {
+                return Ordering::Less;
+            }
+            if j >= b.len() {
+                return Ordering::Greater;
+            }
+            if a.get(i) != Some(&b'^') {
+                return Ordering::Greater;
+            }
+            if b.get(j) != Some(&b'^') {
+                return Ordering::Less;
+            }
+            i += 1;
+            j += 1;
+            continue;
+        }
+
+        // One of the versions ran out of segments
+        if i >= a.len() || j >= b.len() {
+            break;
+        }
+
+        // Compare the next segment, which is either all digits or all letters
+        let numeric = a[i].is_ascii_digit();
+        let a_end = segment_end(a, i, numeric);
+        let b_end = segment_end(b, j, numeric);
+        if j == b_end {
+            // Segments of different kinds, digits are newer than letters
+            return if numeric {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            };
+        }
+        let (mut a_segment, mut b_segment) = (&a[i..a_end], &b[j..b_end]);
+        if numeric {
+            // Leading zeros are not significant, so the number with more digits
+            // left is the larger one
+            while let [b'0', rest @ ..] = a_segment {
+                a_segment = rest;
+            }
+            while let [b'0', rest @ ..] = b_segment {
+                b_segment = rest;
+            }
+            match a_segment.len().cmp(&b_segment.len()) {
+                Ordering::Equal => {}
+                ordering => return ordering,
+            }
+        }
+        match a_segment.cmp(b_segment) {
+            Ordering::Equal => {}
+            ordering => return ordering,
+        }
+        i = a_end;
+        j = b_end;
+    }
+
+    // Whichever version has segments left over is the newer one
+    match (i >= a.len(), j >= b.len()) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Less,
+        (false, _) => Ordering::Greater,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Format;
+    use std::cmp::Ordering;
+
+    #[track_caller]
+    fn assert_order(format: Format, a: &str, ordering: Ordering, b: &str) {
+        assert_eq!(format.compare(a, b), ordering, "comparing {a:?} with {b:?}");
+        assert_eq!(
+            format.compare(b, a),
+            ordering.reverse(),
+            "comparing {b:?} with {a:?}"
+        );
+    }
+
+    #[track_caller]
+    fn assert_deb(a: &str, ordering: Ordering, b: &str) {
+        assert_order(Format::Deb, a, ordering, b);
+    }
+
+    /// Cases from the RPM test suite, which uses -1, 0, and 1
+    #[track_caller]
+    fn assert_rpm(a: &str, expected: i32, b: &str) {
+        let ordering = match expected {
+            -1 => Ordering::Less,
+            0 => Ordering::Equal,
+            _ => Ordering::Greater,
+        };
+        assert_order(Format::Rpm, a, ordering, b);
+    }
+
+    #[test]
+    fn format_from_path() {
+        assert_eq!(
+            Format::from_path("/tmp/foo-1.2.3-1.x86_64.rpm"),
+            Format::Rpm
+        );
+        assert_eq!(Format::from_path("/tmp/FOO.RPM"), Format::Rpm);
+        assert_eq!(Format::from_path("/tmp/foo_1.2.3-1_amd64.deb"), Format::Deb);
+        // Anything unknown falls back to Debian ordering
+        assert_eq!(Format::from_path("/tmp/foo"), Format::Deb);
+    }
+
+    #[test]
+    fn deb_equal() {
+        assert_deb("1.0", Ordering::Equal, "1.0");
+        assert_deb("1.0-1", Ordering::Equal, "1.0-1");
+        // Leading zeros are not significant
+        assert_deb("1.007", Ordering::Equal, "1.7");
+        assert_deb("0:1.0", Ordering::Equal, "1.0");
+        assert_deb("", Ordering::Equal, "");
+    }
+
+    #[test]
+    fn deb_version() {
+        assert_deb("2.0", Ordering::Greater, "1.0");
+        // Numbers are compared numerically, not as text
+        assert_deb("1.10", Ordering::Greater, "1.9");
+        assert_deb("1.0.1", Ordering::Greater, "1.0");
+        assert_deb("1.0a", Ordering::Greater, "1.0");
+        // Versions of the packages from the issue reports
+        assert_deb("2026.01.0-392", Ordering::Greater, "2025.09.2-418");
+        assert_deb("0.11.0-1", Ordering::Greater, "0.9.0-1");
+    }
+
+    #[test]
+    fn deb_tilde_sorts_first() {
+        assert_deb("1.0", Ordering::Greater, "1.0~rc1");
+        assert_deb("1.0~rc2", Ordering::Greater, "1.0~rc1");
+        assert_deb("1.0~rc1", Ordering::Greater, "0.9");
+    }
+
+    #[test]
+    fn deb_epoch() {
+        assert_deb("1:1.0", Ordering::Greater, "2.0");
+        assert_deb("2:1.0", Ordering::Greater, "1:9.0");
+        // A colon that is not part of an epoch is compared as a character
+        assert_deb("1.0:a", Ordering::Greater, "1.0");
+    }
+
+    #[test]
+    fn deb_release() {
+        assert_deb("1.0-2", Ordering::Greater, "1.0-1");
+        assert_deb("1.0-1", Ordering::Greater, "1.0");
+        assert_deb("1.0-1ubuntu2", Ordering::Greater, "1.0-1ubuntu1");
+        assert_deb("1.0-1", Ordering::Greater, "1.0-1~bpo1");
+        // Only the last hyphen separates the release
+        assert_deb("1.0-a-2", Ordering::Greater, "1.0-a-1");
+    }
+
+    /// Cases taken from rpm's own tests/rpmvercmp.at
+    #[test]
+    fn rpm_vercmp() {
+        assert_rpm("1.0", 0, "1.0");
+        assert_rpm("1.0", -1, "2.0");
+        assert_rpm("2.0.1", 0, "2.0.1");
+        assert_rpm("2.0", -1, "2.0.1");
+        assert_rpm("2.0.1a", 1, "2.0.1");
+        assert_rpm("5.5p1", 0, "5.5p1");
+        assert_rpm("5.5p1", -1, "5.5p2");
+        assert_rpm("5.5p10", 0, "5.5p10");
+        assert_rpm("5.5p1", -1, "5.5p10");
+        assert_rpm("10xyz", -1, "10.1xyz");
+        assert_rpm("xyz10", 0, "xyz10");
+        assert_rpm("xyz10", -1, "xyz10.1");
+        assert_rpm("xyz.4", 0, "xyz.4");
+        assert_rpm("xyz.4", -1, "8");
+        assert_rpm("20101121", -1, "20101122");
+        assert_rpm("1.0", 1, "1.fc4");
+        assert_rpm("3.0.0_fc", 0, "3.0.0.fc");
+        // Separators are not significant
+        assert_rpm("2_0", 0, "2.0");
+        assert_rpm("a+", 0, "a_");
+        // Leading zeros are not significant
+        assert_rpm("1.005", 0, "1.5");
+        assert_rpm("1.0010", 1, "1.9");
+    }
+
+    #[test]
+    fn rpm_tilde_and_caret() {
+        assert_rpm("1.0~rc1", -1, "1.0");
+        assert_rpm("1.0~rc1", -1, "1.0~rc2");
+        assert_rpm("1.0~rc1~git123", -1, "1.0~rc1");
+        assert_rpm("1.0^", 1, "1.0");
+        assert_rpm("1.0^", 0, "1.0^");
+        assert_rpm("1.0^git1", 1, "1.0");
+        assert_rpm("1.0^git1", -1, "1.0^git2");
+        assert_rpm("1.0^20160101", -1, "1.0.1");
+        assert_rpm("1.0^git1~pre", -1, "1.0^git1");
+    }
+
+    #[test]
+    fn rpm_epoch_and_release() {
+        assert_rpm("1:1.0-1", 1, "2.0-1");
+        assert_rpm("1.0-2.fc42", 1, "1.0-1.fc42");
+        assert_rpm("1.0-1.fc42", 1, "1.0-1.fc9");
+        // Releases in the style used by upstream RPM downloads
+        assert_rpm("2026.01.0-392.el9", 1, "2025.09.2-418.el9");
+    }
+
+    /// Versions exactly as PackageKit reports them for local `.rpm` files,
+    /// where the epoch is part of the version field of the package ID
+    #[test]
+    fn rpm_package_kit_versions() {
+        assert_rpm("1.1-1.fc44", 1, "1.0-1.fc44");
+        assert_rpm("1:0.9-1.fc44", 1, "1.0-1.fc44");
+        assert_rpm("1:1.2-1", 1, "1.0-1");
+    }
+
+
+    /// Cases where the two formats disagree, which is why the file the package
+    /// came from decides how it is compared
+    #[test]
+    fn formats_disagree() {
+        // RPM treats digits as newer than letters, dpkg does not
+        assert_rpm("1.0", 1, "1.fc4");
+        assert_deb("1.0", Ordering::Less, "1.fc4");
+        // RPM ignores separators, dpkg compares them
+        assert_rpm("1.0^20160101", -1, "1.0.1");
+        assert_deb("1.0^20160101", Ordering::Greater, "1.0.1");
+    }
+}

--- a/src/view.rs
+++ b/src/view.rs
@@ -181,6 +181,18 @@ impl App {
                 }
             }
         }
+        // A package file can contain a newer version than the installed one, which
+        // the package manager knows nothing about
+        let file_update = update_opt.is_none()
+            && self.file_update_available(selected_backend_name, selected_id, selected_info);
+        if file_update {
+            update_opt = Some(Message::Operation(
+                OperationKind::Update,
+                selected_backend_name,
+                selected_id.clone(),
+                selected_info.clone(),
+            ));
+        }
         let mut progress_opt = None;
         for (_id, (op, progress)) in self.pending_operations.iter() {
             if op.backend_name == selected_backend_name
@@ -228,9 +240,15 @@ impl App {
             }
             if let Some(update) = update_opt {
                 buttons.push(
-                    widget::button::standard(fl!("update"))
-                        .on_press(update)
-                        .into(),
+                    // Updating is the reason a package file was opened, so
+                    // suggest it over uninstalling
+                    if file_update {
+                        widget::button::suggested(fl!("update"))
+                    } else {
+                        widget::button::standard(fl!("update"))
+                    }
+                    .on_press(update)
+                    .into(),
                 );
             }
             if !selected_id.is_system() {


### PR DESCRIPTION
Closes #494. Closes #431.

## Problem

Opening a `.deb` that contains a newer version of an already installed package shows only an **Uninstall** button, so there is no way to upgrade from the file. The workaround in both issues is `sudo apt install ./file.deb`, which does the right thing.

The version is already resolved: `Backend::file_packages()` returns it from PackageKit's `GetDetailsLocal`. But `handle_file_url()` dropped it when building search results, and the detail page only offers Update for packages present in the backend's update list — which comes from `GetUpdates` and cannot know about a file on disk.

## Change

* The version a package file contains and the version currently installed for it are kept in `App::file_versions`, filled in when the file is opened. A new `Backend::installed_version()` (default `None`, implemented for PackageKit) resolves the installed side.
* The detail page offers **Update** when the file is the newer of the two, styled as the suggested action since updating is why the file was opened. It disappears once an operation on that package finishes.
* `OperationKind::Update` installs the file when the package info carries package paths, which is what `apt install ./file.deb` does. Calling `UpdatePackages` would fail for a package that exists in no repository. Resolving package names is now skipped when operating on files, for the same reason.
* New `src/version.rs` compares versions using the rules of the format the file came from. Debian and RPM genuinely disagree — RPM ignores separators and sorts digits above letters, so dpkg rules invert the result for strings as ordinary as `1.0` against `1.fc4`. The RPM path also handles the epoch that PackageKit reports inside the version field (`1:0.9-1.fc44`).
* `application/x-rpm` added to the metainfo mime types, which had fallen out of sync with the desktop file.

No new translatable strings; the existing `update` key is reused.

## Testing

**Deb, on Pop!_OS 24.04:** opening `cosmic-media-now-playing-applet_0.11.0-1_amd64.deb` with `0.9.0-1` installed now shows Update next to Uninstall, and installs the file. Verified `GetDetailsLocal` returns `cosmic-media-now-playing-applet;0.11.0-1;amd64;local` while `Resolve(Installed)` returns `0.9.0-1`.

**RPM, in a Fedora container:**

* Version ordering was differentially tested against `rpm.labelCompare` from librpm 6.0.1 — 24,190 generated cases (18,190 random version strings including `~`, `^` and shared prefixes, plus 6,000 full `epoch:version-release` strings), all matching.
* The PackageKit dnf5 backend was exercised end to end with locally built RPMs: `GetDetailsLocal` returns `cosmic-test;1.1-1.fc44;noarch;@commandline`, `Resolve(Installed)` returns `cosmic-test;1.0-1.fc44;noarch;installed`, and `InstallFiles` with the newer file reports `Updated cosmic-test-1.1-1` / `Cleaned up cosmic-test-1.0-1`.
* Unit tests cover both formats, including the cases from rpm's own `tests/rpmvercmp.at` and versions captured from PackageKit.

The GUI itself has not been exercised on an RPM distro, only the library and PackageKit behaviour it depends on.

## Known limitations

* PackageKit's dnf5 backend fails `InstallFiles` with *"Package was not found in rpm database"* when a file's epoch is higher but its version string is lower (`1:0.9-1` over `1.0-1`), even though `dnf install` upgrades it. The comparison here follows rpm and dnf in treating that as newer, so the button is offered and the failure surfaces in the operations dialog. Suppressing it would hide a legitimate update and would be wrong for Debian, where apt handles this fine.
* rpm-ostree systems are unaffected: that backend rejects file-based package parsing and per-package operations, so local package files still do nothing there. Supporting them would mean package layering, which belongs in a separate change.
